### PR TITLE
Enforce album access for chats

### DIFF
--- a/app/utils/concurrent.py
+++ b/app/utils/concurrent.py
@@ -17,6 +17,16 @@ def participation_controller(album_id: int, db: Session, current_user: UserRespo
     )).first()
     return album, participant
 
+def verify_album_access(album_id: int, db: Session, current_user: UserResponse):
+    """Return the album if the user is the owner or a participant.
+
+    Raises a 403 error if the user has no permissions.
+    """
+    album, participant = participation_controller(album_id, db, current_user)
+    if album.owner_id != current_user.id and not participant:
+        raise HTTPException(status_code=403, detail="Album not found")
+    return album
+
 def get_image(album_id: int, image_id: int, db: Session):
     image = db.exec(select(models.Image).where(
         and_(


### PR DESCRIPTION
## Summary
- add `verify_album_access` helper for permission checking
- require album owner/participant for chat and message routes

## Testing
- `python -m py_compile app/routes/messages.py app/utils/concurrent.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68883a46fc8083329b28df90e715b450